### PR TITLE
Align env var name for model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ DOMAIN=your_domain_here
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
 # Available models: coder, chat, openrouter
-MODEL=google/gemini-2.0-flash-001
+OPENROUTER_MODEL=google/gemini-2.0-flash-001
 # deepseek/deepseek-r1
 # qwen/qwen-2.5-coder-32b-instruct
 # mistralai/codestral-2501

--- a/proxy.go
+++ b/proxy.go
@@ -92,7 +92,7 @@ func putBuffer(buf *bytes.Buffer) {
 func init() {
 	// Check environment variables first
 	openRouterAPIKey = os.Getenv("OPENROUTER_API_KEY")
-	defaultModel := os.Getenv("MODEL")
+	defaultModel := os.Getenv("OPENROUTER_MODEL")
 
 	// If key or model is missing, try loading from .env file
 	if openRouterAPIKey == "" || defaultModel == "" {
@@ -103,7 +103,7 @@ func init() {
 			openRouterAPIKey = os.Getenv("OPENROUTER_API_KEY")
 		}
 		if defaultModel == "" {
-			defaultModel = os.Getenv("MODEL")
+			defaultModel = os.Getenv("OPENROUTER_MODEL")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- update proxy to read `OPENROUTER_MODEL`
- rename variable in `.env.example`

## Testing
- `go vet ./...`
- `go build`

------
https://chatgpt.com/codex/tasks/task_e_6842b9b3e3f0832bba75df67186fa59a